### PR TITLE
fix: buckets calculations

### DIFF
--- a/crates/web-ui/src/components/buckets_chart.rs
+++ b/crates/web-ui/src/components/buckets_chart.rs
@@ -45,7 +45,7 @@ pub(crate) fn BucketsChart(buckets: ReadSignal<Buckets>) -> impl IntoView {
                             .iter()
                             .map(|b| XYPoint {
                                 x: b.number().into(),
-                                y: b.start().into(),
+                                y: b.le().into(),
                                 description: String::new(),
                             })
                             .collect::<Vec<_>>()

--- a/crates/web-ui/src/components/buckets_table.rs
+++ b/crates/web-ui/src/components/buckets_table.rs
@@ -3,15 +3,7 @@ use leptos::{component, view, CollectView, IntoView, ReadSignal, SignalWith};
 use leptos_use::{use_intl_number_format, Notation, UseIntlNumberFormatOptions};
 
 #[component]
-pub(crate) fn BucketsTable(
-    buckets: ReadSignal<Buckets>,
-    #[prop(into)] headers: Vec<String>,
-) -> impl IntoView {
-    let head_columns = headers
-        .iter()
-        .map(|header| view! { <th class="text-start" scope="col">{header}</th> })
-        .collect_view();
-
+pub(crate) fn BucketsTable(buckets: ReadSignal<Buckets>) -> impl IntoView {
     let rounded_float_format = use_intl_number_format(
         UseIntlNumberFormatOptions::default()
             .notation(Notation::Compact)
@@ -27,8 +19,7 @@ pub(crate) fn BucketsTable(
                     view! {
                         <tr>
                             <td class="text-start" scope="col">{bucket.number()}</td>
-                            <td class="text-start" scope="col" title={bucket.start()}>{rounded_float_format.format(bucket.start())}</td>
-                            <td class="text-start" scope="col" title={bucket.end()}>{rounded_float_format.format(bucket.end())}</td>
+                            <td class="text-start" scope="col" title={bucket.le()}>{rounded_float_format.format(bucket.le())}</td>
                         </tr>
                     }
                 })
@@ -41,7 +32,8 @@ pub(crate) fn BucketsTable(
             <table class="table table-hover">
                 <thead>
                     <tr>
-                        {head_columns}
+                        <th class="text-start" scope="col">#</th>
+                        <th class="text-start" scope="col">Less than or equal to</th>
                     </tr>
                 </thead>
                 {buckets_view}

--- a/crates/web-ui/src/pages/buckets_explorer_page.rs
+++ b/crates/web-ui/src/pages/buckets_explorer_page.rs
@@ -46,11 +46,6 @@ pub(crate) fn BucketsExplorerPage() -> impl IntoView {
         ))
     };
 
-    let table_header = ["#", "From", "To (exclusive)"]
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>();
-
     view! {
         <div class="container mt-4">
             <h1 class="mb-4">Exponential Buckets Explorer</h1>
@@ -76,10 +71,10 @@ pub(crate) fn BucketsExplorerPage() -> impl IntoView {
 
             <div class="mb-4 row">
                 {/* Bucket Distribution Table */}
-                <div class="col-sm-6 text-center">
-                    <h2>Bucket Distribution Table</h2>
+                <div class="col-sm-auto text-center">
+                    <h2>Buckets</h2>
 
-                    <BucketsTable buckets=buckets headers=table_header />
+                    <BucketsTable buckets=buckets />
                 </div>
                 {/* Chart */}
                 <div class="col-sm-6 text-center">

--- a/crates/web-ui/src/types/mod.rs
+++ b/crates/web-ui/src/types/mod.rs
@@ -1,4 +1,4 @@
-use std::ops::{Deref, Range};
+use std::ops::Deref;
 
 #[derive(Debug, Clone)]
 pub(crate) struct Buckets(Vec<Bucket>);
@@ -6,52 +6,43 @@ pub(crate) struct Buckets(Vec<Bucket>);
 #[derive(Debug, Clone)]
 pub(crate) struct Bucket {
     number: u32,
-    range: Range<f64>,
+    le: f64,
 }
 
 impl Buckets {
     pub(crate) fn calculate(initial_value: f64, factor: f64, num_of_buckets: u32) -> Self {
-        // Overflow isn't possible due to validations, but this api is isolated
-        // TODO: use bounded integer type to restrict passing too large values
-        let capacity = num_of_buckets
+        // Include last bucket, which is open ended
+        // TODO: use bounded integer type to restrict passing too large values.
+        //      Overflow isn't possible due to validations, but this api is isolated
+        let num_of_buckets = num_of_buckets
             .checked_add(1)
             .expect("number of buckets - overflow");
-
-        let mut buckets = Vec::with_capacity(capacity as usize);
-        buckets.push(Bucket::new(1, 0.0..initial_value));
-
-        let mut current_value = initial_value;
+        let mut buckets = Vec::with_capacity(num_of_buckets as usize);
+        let mut next_value = initial_value;
 
         // starting from second bucket, since first one is already added
-        if num_of_buckets > 2 {
-            for bucket_num in 2..num_of_buckets {
-                let next_value = current_value * factor;
-                buckets.push(Bucket::new(bucket_num, current_value..next_value));
-                current_value = next_value;
-            }
+        for bucket_num in 1..num_of_buckets {
+            buckets.push(Bucket::new(bucket_num, next_value));
+            next_value *= factor;
         }
         // last bucket is open ended
-        buckets.push(Bucket::new(num_of_buckets, current_value..f64::INFINITY));
+        buckets.push(Bucket::new(num_of_buckets, f64::INFINITY));
 
         Self(buckets)
     }
 }
 
 impl Bucket {
-    fn new(number: u32, range: Range<f64>) -> Self {
-        Self { number, range }
+    fn new(number: u32, le: f64) -> Self {
+        Self { number, le }
     }
 
     pub fn number(&self) -> u32 {
         self.number
     }
 
-    pub fn start(&self) -> f64 {
-        self.range.start
-    }
-
-    pub fn end(&self) -> f64 {
-        self.range.end
+    pub fn le(&self) -> f64 {
+        self.le
     }
 }
 


### PR DESCRIPTION
It's hard to represent buckets as ranges, because of actual rule is:
bucket is less than or equal to the value, but greater than previous bucket.

But for first bucket the initial value is 0 which is inclusive.

Need to think how improve the UX